### PR TITLE
Fix pricing fetch mis-mapping newer Claude models (Opus 4.8 priced as Opus 4)

### DIFF
--- a/ClaudeStatistics/Models/Session.swift
+++ b/ClaudeStatistics/Models/Session.swift
@@ -138,6 +138,7 @@ final class ModelPricing {
         if lower.contains("gemini-3-pro") { return models["gemini-3-pro-preview"] ?? defaultPricing }
         if lower.contains("gemini-3.1-flash-lite") { return models["gemini-3.1-flash-lite-preview"] ?? defaultPricing }
         if lower.contains("gemini-3-flash") { return models["gemini-3-flash-preview"] ?? defaultPricing }
+        if lower.contains("gpt-5.5") { return models["gpt-5.5"] ?? defaultPricing }
         if lower.contains("gpt-5.4-mini") { return models["gpt-5.4-mini"] ?? defaultPricing }
         if lower.contains("gpt-5.4") { return models["gpt-5.4"] ?? defaultPricing }
         if lower.contains("gpt-5.3-codex") { return models["gpt-5.3-codex"] ?? defaultPricing }
@@ -153,6 +154,7 @@ final class ModelPricing {
             if lower.contains("flash") { return models["gemini-2.5-flash"] ?? defaultPricing }
             if lower.contains("pro") { return models["gemini-2.5-pro"] ?? defaultPricing }
         }
+        if lower.contains("opus-4-8") { return models["claude-opus-4-8"] ?? defaultPricing }
         if lower.contains("opus-4-7") { return models["claude-opus-4-7"] ?? defaultPricing }
         if lower.contains("opus-4-6") { return models["claude-opus-4-6"] ?? defaultPricing }
         if lower.contains("opus-4-5") { return models["claude-opus-4-5-20251101"] ?? defaultPricing }

--- a/ClaudeStatistics/Providers/Claude/ClaudeProvider.swift
+++ b/ClaudeStatistics/Providers/Claude/ClaudeProvider.swift
@@ -189,6 +189,7 @@ struct ClaudeStatusLineAdapter: StatusLineInstalling {
 enum ClaudePricingCatalog {
     // Source: Anthropic Claude pricing (2026-03-20)
     static let builtinModels: [String: ModelPricing.Pricing] = [
+        "claude-opus-4-8":            ModelPricing.Pricing(input: 5.0, output: 25.0, cacheWrite5m: 6.25, cacheWrite1h: 10.0, cacheRead: 0.50),
         "claude-opus-4-7":            ModelPricing.Pricing(input: 5.0, output: 25.0, cacheWrite5m: 6.25, cacheWrite1h: 10.0, cacheRead: 0.50),
         "claude-opus-4-6":            ModelPricing.Pricing(input: 5.0, output: 25.0, cacheWrite5m: 6.25, cacheWrite1h: 10.0, cacheRead: 0.50),
         "claude-opus-4-5-20251101":   ModelPricing.Pricing(input: 5.0, output: 25.0, cacheWrite5m: 6.25, cacheWrite1h: 10.0, cacheRead: 0.50),

--- a/ClaudeStatistics/Providers/PricingFetchService.swift
+++ b/ClaudeStatistics/Providers/PricingFetchService.swift
@@ -134,6 +134,7 @@ final class PricingFetchService: ProviderPricingFetching {
 
         let mappings: [(pattern: String, ids: [String])] = [
             // Latest
+            ("opus 4.8",   ["claude-opus-4-8"]),
             ("opus 4.7",   ["claude-opus-4-7"]),
             ("opus 4.6",   ["claude-opus-4-6"]),
             ("opus 4.5",   ["claude-opus-4-5-20251101"]),
@@ -144,19 +145,63 @@ final class PricingFetchService: ProviderPricingFetching {
             ("sonnet 4.5", ["claude-sonnet-4-5-20250929"]),
             ("sonnet 4",   ["claude-sonnet-4-20250514"]),
             ("sonnet 3.7", ["claude-3-7-sonnet-20250219"]),
-            ("haiku 4.5",  ["claude-haiku-4-5-20251001"]),
+            ("haiku 4.5",  ["claude-haiku-4-5-20251001", "claude-haiku-4-5"]),
             ("haiku 3.5",  ["claude-3-5-haiku-20241022"]),
             ("haiku 3",    ["claude-3-haiku-20240307"]),
         ]
 
         for mapping in mappings {
-            if name.contains(mapping.pattern) {
+            // Match on a complete version token so a base pattern like
+            // "opus 4" never swallows a newer minor release such as
+            // "opus 4.8" (which used to fall through to the wrong base id).
+            if matchesVersionToken(name, mapping.pattern) {
                 return mapping.ids
             }
         }
 
-        // Fallback: construct a reasonable ID
-        return [displayName.lowercased().replacingOccurrences(of: " ", with: "-")]
+        // Fallback for any model not in the table above (e.g. a release
+        // newer than this build): derive the canonical Anthropic-style id
+        // straight from the display name instead of a naive slug. This is
+        // what keeps "Claude Opus 4.8" → "claude-opus-4-8" rather than the
+        // old "opus-4.8" (dotted, un-prefixed) that matched nothing.
+        return [canonicalModelId(from: displayName)]
+    }
+
+    /// True if `pattern` (e.g. "opus 4.8") appears in `name` as a complete
+    /// version token — not as the prefix of a longer version. Without this,
+    /// the "opus 4" pattern matches "claude opus 4.8" via plain `contains`
+    /// and the new model gets priced as the old base model.
+    private func matchesVersionToken(_ name: String, _ pattern: String) -> Bool {
+        guard let range = name.range(of: pattern) else { return false }
+        let rest = name[range.upperBound...]
+        guard let next = rest.first else { return true }   // pattern ends the string
+        if next.isNumber { return false }                  // e.g. "opus 4" vs "opus 40"
+        if next == "." {
+            // ".<digit>" means a longer minor version (e.g. "opus 4" vs "opus 4.8")
+            if let after = rest.dropFirst().first, after.isNumber { return false }
+        }
+        return true
+    }
+
+    /// Derive a canonical Anthropic model id from a docs display name.
+    ///   "Claude Opus 4.8"                        -> "claude-opus-4-8"
+    ///   "Claude Mythos 5 (limited availability)" -> "claude-mythos-5"
+    /// Drops parenthetical qualifiers and collapses dots/spaces to dashes so
+    /// the id matches the dash-delimited model strings used in transcripts.
+    private func canonicalModelId(from displayName: String) -> String {
+        var text = displayName.lowercased()
+        if let paren = text.firstIndex(of: "(") {
+            text = String(text[..<paren])
+        }
+        let separators = CharacterSet(charactersIn: " ./_")
+        let parts = text
+            .components(separatedBy: separators)
+            .filter { !$0.isEmpty }
+        var id = parts.joined(separator: "-")
+        if !id.hasPrefix("claude-") {
+            id = "claude-" + id
+        }
+        return id
     }
 }
 


### PR DESCRIPTION
## The bug

*Settings → Manage Model Pricing → Refresh pricing* could not price **Claude Opus 4.8** correctly. All Opus 4.8 usage was billed at the old Opus 4 rate (**$15 / $75** instead of **$5 / $25** — a 3× overcharge), and stale/junk keys leaked into `pricing.json`.

Root cause is in `PricingFetchService.mapToModelIds`, which maps a docs display name to API model ids via an ordered **substring** table:

```swift
if name.contains(mapping.pattern) { return mapping.ids }
```

- There is **no `opus 4.8` entry**, and matching is plain `contains`, so `"claude opus 4.8"` matches the shorter `"opus 4"` pattern and returns `["claude-opus-4-20250514"]`. The fetched Opus 4.8 price is written onto the **old Opus 4** key, and the id the app actually keys cost on — `claude-opus-4-8` — never gets a price. On the consumption side `pricing(for:)` has the same gap, so `claude-opus-4-8` also falls through `opus-4` to the $15/$75 base model.
- The fallback for unlisted models was a naive slug:
  ```swift
  return [displayName.lowercased().replacingOccurrences(of: " ", with: "-")]
  ```
  which produces malformed ids like `opus-4.8` (dotted, no `claude-` prefix) or `claude-mythos-5-(limited-availability)` (parenthetical qualifier baked into the id) — neither matches anything.

## The fix

`ClaudeStatistics/Providers/PricingFetchService.swift`:
- Add the `opus 4.8 → claude-opus-4-8` mapping.
- Replace `contains` with **`matchesVersionToken`**, which requires the version to match as a complete token, so `"opus 4"` no longer swallows `"opus 4.8"` (or any future `4.x`).
- Replace the slug fallback with **`canonicalModelId`**: strips parenthetical qualifiers, collapses dots/spaces/underscores to dashes, and guarantees the `claude-` prefix — so `Claude Opus 4.8 → claude-opus-4-8`, `Claude Mythos 5 (limited availability) → claude-mythos-5`, and an unreleased `Claude Opus 4.9 → claude-opus-4-9` all degrade to correct-format ids instead of mismatching or producing junk.

`ClaudeStatistics/Providers/Claude/ClaudeProvider.swift`:
- Seed `claude-opus-4-8` ($5/$25, cache 6.25/10/0.50) into `ClaudePricingCatalog.builtinModels` so it's correct even before a refresh.

`ClaudeStatistics/Models/Session.swift`:
- Add `opus-4-8` (and `gpt-5.5`) branches to `pricing(for:)` so the consumption side resolves the new ids ahead of the older base-model catch-alls.

## Result

Verified the new mapping logic in isolation (12 assertions, all pass):

| display name | before | after |
|---|---|---|
| Claude Opus 4.8 | `claude-opus-4-20250514` ❌ | `claude-opus-4-8` ✅ |
| Claude Opus 4 (base) | `claude-opus-4-20250514` | `claude-opus-4-20250514` (unchanged) |
| Claude Opus 4.9 (future) | `claude-opus-4-20250514` ❌ | `claude-opus-4-9` ✅ |
| Claude Mythos 5 (limited availability) | `claude-mythos-5-(limited-availability)` ❌ | `claude-mythos-5` ✅ |

Built the host app (Release) with these changes, installed it, and confirmed Opus 4.8 sessions now price at $5/$25 and *Refresh pricing* writes the correct `claude-opus-4-8` key with no junk entries.

> Note: this is the Claude half of a two-part fix. The OpenAI/Codex half (the Codex plugin's fetcher only updated one model and lacked gpt-5.5) is a separate PR against `sj719045032/claude-statistics-plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)