### PR TITLE
Count Claude Desktop "Cowork" usage in the statistics (with a Cowork vs Claude Code split)

### DIFF
--- a/ClaudeStatistics/Models/AggregateStats.swift
+++ b/ClaudeStatistics/Models/AggregateStats.swift
@@ -155,13 +155,34 @@ struct PeriodStats: Identifiable {
     var hasEstimatedCost: Bool = false
     var modelBreakdown: [String: ModelUsage] = [:]
 
+    // Cowork (Claude Desktop local agent mode) subset of the totals above, so
+    // the UI can show a "Cowork vs Claude Code" split. Claude Code = total − Cowork.
+    var coworkCost: Double = 0
+    var coworkTokens: Int = 0
+    var coworkMessageCount: Int = 0
+
     var id: Date { period }
 
     var totalTokens: Int {
         totalInputTokens + totalOutputTokens + cacheCreationTotalTokens + cacheReadTokens
     }
 
-    mutating func accumulate(daySlice slice: DaySlice) {
+    var claudeCodeCost: Double { max(0, totalCost - coworkCost) }
+    var claudeCodeTokens: Int { max(0, totalTokens - coworkTokens) }
+    var claudeCodeMessageCount: Int { max(0, messageCount - coworkMessageCount) }
+    var hasCoworkUsage: Bool { coworkTokens > 0 || coworkCost > 0 }
+
+    mutating func accumulate(daySlice slice: DaySlice, origin: SessionOrigin = .claudeCode) {
+        if origin == .cowork {
+            coworkCost += slice.estimatedCost
+            coworkTokens += slice.totalInputTokens + slice.totalOutputTokens
+                + slice.cacheCreationTotalTokens + slice.cacheReadTokens
+            coworkMessageCount += slice.messageCount
+        }
+        accumulateTotals(daySlice: slice)
+    }
+
+    private mutating func accumulateTotals(daySlice slice: DaySlice) {
         totalInputTokens += slice.totalInputTokens
         totalOutputTokens += slice.totalOutputTokens
         cacheCreation5mTokens += slice.cacheCreation5mTokens
@@ -201,7 +222,17 @@ struct PeriodStats: Identifiable {
         }
     }
 
-    mutating func accumulate(stats: SessionStats) {
+    mutating func accumulate(stats: SessionStats, origin: SessionOrigin = .claudeCode) {
+        if origin == .cowork {
+            coworkCost += stats.estimatedCost
+            coworkTokens += stats.totalInputTokens + stats.totalOutputTokens
+                + stats.cacheCreationTotalTokens + stats.cacheReadTokens
+            coworkMessageCount += stats.messageCount
+        }
+        accumulateTotals(stats: stats)
+    }
+
+    private mutating func accumulateTotals(stats: SessionStats) {
         totalInputTokens += stats.totalInputTokens
         totalOutputTokens += stats.totalOutputTokens
         cacheCreation5mTokens += stats.cacheCreation5mTokens

--- a/ClaudeStatistics/Providers/Claude/ClaudeProvider.swift
+++ b/ClaudeStatistics/Providers/Claude/ClaudeProvider.swift
@@ -48,9 +48,34 @@ final class ClaudeProvider: SessionProvider, @unchecked Sendable {
     }
 
     func makeWatcher(onChange: @escaping (Set<String>) -> Void) -> (any SessionWatcher)? {
+        let fm = FileManager.default
+        var watchers: [any SessionWatcher] = []
+
         let projectsDir = (CredentialService.shared.claudeConfigDir() as NSString).appendingPathComponent("projects")
-        guard FileManager.default.fileExists(atPath: projectsDir) else { return nil }
-        return FSEventsWatcher(path: projectsDir, debounceSeconds: 2.0, onChange: onChange)
+        if fm.fileExists(atPath: projectsDir) {
+            watchers.append(FSEventsWatcher(path: projectsDir, debounceSeconds: 2.0, onChange: onChange))
+        }
+
+        // Also watch the Cowork (local agent mode) tree so its usage updates
+        // live. Filter to real transcripts only — the tree also holds workspace
+        // files, audit logs, and subagent transcripts we don't ingest.
+        let coworkRoot = (NSHomeDirectory() as NSString)
+            .appendingPathComponent("Library/Application Support/Claude/local-agent-mode-sessions")
+        if fm.fileExists(atPath: coworkRoot) {
+            watchers.append(FSEventsWatcher(
+                path: coworkRoot,
+                debounceSeconds: 2.0,
+                fileFilter: { path in
+                    path.hasSuffix(".jsonl")
+                        && path.contains("/.claude/projects/")
+                        && !path.contains("/subagents/")
+                },
+                onChange: onChange
+            ))
+        }
+
+        guard !watchers.isEmpty else { return nil }
+        return watchers.count == 1 ? watchers[0] : CompositeSessionWatcher(watchers: watchers)
     }
 
     func changedSessionIds(for changedPaths: Set<String>) -> Set<String> {

--- a/ClaudeStatistics/Providers/Claude/CompositeSessionWatcher.swift
+++ b/ClaudeStatistics/Providers/Claude/CompositeSessionWatcher.swift
@@ -1,0 +1,22 @@
+import Foundation
+import ClaudeStatisticsKit
+
+/// Fans `start()` / `stop()` out to several `SessionWatcher`s so a provider can
+/// watch more than one root directory behind a single watcher handle. The
+/// Claude provider uses it to watch both `~/.claude/projects` and the Cowork
+/// (local agent mode) transcript tree.
+final class CompositeSessionWatcher: SessionWatcher {
+    private let watchers: [any SessionWatcher]
+
+    init(watchers: [any SessionWatcher]) {
+        self.watchers = watchers
+    }
+
+    func start() {
+        for watcher in watchers { watcher.start() }
+    }
+
+    func stop() {
+        for watcher in watchers { watcher.stop() }
+    }
+}

--- a/ClaudeStatistics/Providers/Claude/SessionOrigin.swift
+++ b/ClaudeStatistics/Providers/Claude/SessionOrigin.swift
@@ -1,0 +1,34 @@
+import Foundation
+import ClaudeStatisticsKit
+
+/// Where a scanned Claude session was produced.
+///
+/// Claude Code writes transcripts to `~/.claude/projects`. Claude Desktop's
+/// "Cowork" (local agent mode) runs a sandboxed Claude Code whose transcripts
+/// live under the desktop app's Application Support tree
+/// (`~/Library/Application Support/Claude/local-agent-mode-sessions/.../.claude/projects/`).
+/// The two trees never overlap, so the transcript path is a reliable origin
+/// discriminator — there is no schema field to key on.
+enum SessionOrigin: String, CaseIterable {
+    case claudeCode
+    case cowork
+
+    /// Marker substring present only in Cowork (local-agent-mode) transcript paths.
+    static let coworkPathMarker = "local-agent-mode-sessions"
+
+    static func of(filePath: String) -> SessionOrigin {
+        filePath.contains(coworkPathMarker) ? .cowork : .claudeCode
+    }
+
+    static func of(_ session: Session) -> SessionOrigin {
+        of(filePath: session.filePath)
+    }
+
+    /// Human-readable label. These are product names, not localized strings.
+    var displayName: String {
+        switch self {
+        case .claudeCode: return "Claude Code"
+        case .cowork: return "Cowork"
+        }
+    }
+}

--- a/ClaudeStatistics/Providers/Claude/SessionScanner.swift
+++ b/ClaudeStatistics/Providers/Claude/SessionScanner.swift
@@ -26,49 +26,108 @@ final class SessionScanner {
             guard let files = try? fm.contentsOfDirectory(atPath: projectPath) else { continue }
 
             for file in files where file.hasSuffix(".jsonl") {
-                let filePath = (projectPath as NSString).appendingPathComponent(file)
-                let sessionId = (file as NSString).deletingPathExtension
-                let uniqueSessionId = Self.uniqueSessionId(projectDirectory: projectDir, transcriptFileName: file)
-
-                guard let attrs = try? fm.attributesOfItem(atPath: filePath) else { continue }
-                let modDate = attrs[.modificationDate] as? Date ?? Date.distantPast
-                let fileSize = attrs[.size] as? Int64 ?? 0
-
-                // Skip tiny files (likely empty sessions)
-                guard fileSize > 100 else { continue }
-
-                // Include subagent file sizes for cache invalidation
-                var combinedSize = fileSize
-                let subagentDir = (projectPath as NSString)
-                    .appendingPathComponent(sessionId)
-                    .appending("/subagents")
-                if let subFiles = try? fm.contentsOfDirectory(atPath: subagentDir) {
-                    for subFile in subFiles where subFile.hasSuffix(".jsonl") {
-                        let subPath = (subagentDir as NSString).appendingPathComponent(subFile)
-                        if let subAttrs = try? fm.attributesOfItem(atPath: subPath),
-                           let subSize = subAttrs[.size] as? Int64 {
-                            combinedSize += subSize
-                        }
-                    }
+                if let session = makeSession(projectPath: projectPath, projectDirectory: projectDir, file: file) {
+                    sessions.append(session)
                 }
-
-                let cwd = readCwd(from: filePath)
-
-                sessions.append(Session(
-                    id: uniqueSessionId,
-                    externalID: sessionId,
-                    provider: ProviderKind.claude.rawValue,
-                    projectPath: projectDir,
-                    filePath: filePath,
-                    startTime: nil,
-                    lastModified: modDate,
-                    fileSize: combinedSize,
-                    cwd: cwd
-                ))
             }
         }
 
+        // Claude Desktop "Cowork" (local agent mode) sessions live outside
+        // ~/.claude/projects, so they are invisible to the scan above. Fold
+        // them in so their tokens/cost reach the same statistics pipeline.
+        sessions.append(contentsOf: scanCoworkSessions())
+
         return sessions.sorted { $0.lastModified > $1.lastModified }
+    }
+
+    /// Scan Claude Desktop "Cowork" transcripts. Cowork runs a sandboxed Claude
+    /// Code whose `~/.claude` is redirected into the desktop app's per-session
+    /// workspace, so the standard-format transcripts land at:
+    ///   ~/Library/Application Support/Claude/local-agent-mode-sessions/
+    ///     <workspace>/<session>/local_<id>/.claude/projects/<proj>/<uuid>.jsonl
+    /// We walk only that fixed structure (not `outputs/`, not `audit.jsonl`,
+    /// not `subagents/`) so we pick exactly the main transcripts — the same set
+    /// the regular scanner would pick under ~/.claude/projects.
+    func scanCoworkSessions() -> [Session] {
+        let fm = FileManager.default
+        let root = (NSHomeDirectory() as NSString)
+            .appendingPathComponent("Library/Application Support/Claude/local-agent-mode-sessions")
+        guard fm.fileExists(atPath: root) else { return [] }
+
+        var sessions: [Session] = []
+        let workspaces = (try? fm.contentsOfDirectory(atPath: root)) ?? []
+        for workspace in workspaces {
+            let workspacePath = (root as NSString).appendingPathComponent(workspace)
+            let sessionDirs = (try? fm.contentsOfDirectory(atPath: workspacePath)) ?? []
+            for sessionDir in sessionDirs {
+                let sessionPath = (workspacePath as NSString).appendingPathComponent(sessionDir)
+                let locals = (try? fm.contentsOfDirectory(atPath: sessionPath)) ?? []
+                for local in locals where local.hasPrefix("local_") {
+                    let projectsRoot = (sessionPath as NSString)
+                        .appendingPathComponent(local)
+                        .appending("/.claude/projects")
+                    let projectDirs = (try? fm.contentsOfDirectory(atPath: projectsRoot)) ?? []
+                    for projectDir in projectDirs {
+                        let projectPath = (projectsRoot as NSString).appendingPathComponent(projectDir)
+                        var isDir: ObjCBool = false
+                        guard fm.fileExists(atPath: projectPath, isDirectory: &isDir), isDir.boolValue else { continue }
+                        let files = (try? fm.contentsOfDirectory(atPath: projectPath)) ?? []
+                        for file in files where file.hasSuffix(".jsonl") {
+                            if let session = makeSession(projectPath: projectPath, projectDirectory: projectDir, file: file) {
+                                sessions.append(session)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return sessions
+    }
+
+    /// Build a `Session` from a single transcript file. Shared by the regular
+    /// and Cowork scans so both apply the same size floor, subagent-size
+    /// rollup (for cache invalidation), and cwd extraction.
+    private func makeSession(projectPath: String, projectDirectory: String, file: String) -> Session? {
+        let fm = FileManager.default
+        let filePath = (projectPath as NSString).appendingPathComponent(file)
+        let sessionId = (file as NSString).deletingPathExtension
+        let uniqueSessionId = Self.uniqueSessionId(projectDirectory: projectDirectory, transcriptFileName: file)
+
+        guard let attrs = try? fm.attributesOfItem(atPath: filePath) else { return nil }
+        let modDate = attrs[.modificationDate] as? Date ?? Date.distantPast
+        let fileSize = attrs[.size] as? Int64 ?? 0
+
+        // Skip tiny files (likely empty sessions)
+        guard fileSize > 100 else { return nil }
+
+        // Include subagent file sizes for cache invalidation
+        var combinedSize = fileSize
+        let subagentDir = (projectPath as NSString)
+            .appendingPathComponent(sessionId)
+            .appending("/subagents")
+        if let subFiles = try? fm.contentsOfDirectory(atPath: subagentDir) {
+            for subFile in subFiles where subFile.hasSuffix(".jsonl") {
+                let subPath = (subagentDir as NSString).appendingPathComponent(subFile)
+                if let subAttrs = try? fm.attributesOfItem(atPath: subPath),
+                   let subSize = subAttrs[.size] as? Int64 {
+                    combinedSize += subSize
+                }
+            }
+        }
+
+        let cwd = readCwd(from: filePath)
+
+        return Session(
+            id: uniqueSessionId,
+            externalID: sessionId,
+            provider: ProviderKind.claude.rawValue,
+            projectPath: projectDirectory,
+            filePath: filePath,
+            startTime: nil,
+            lastModified: modDate,
+            fileSize: combinedSize,
+            cwd: cwd
+        )
     }
 
     static func uniqueSessionId(projectDirectory: String, transcriptFileName: String) -> String {

--- a/ClaudeStatistics/Services/SessionDataStore.swift
+++ b/ClaudeStatistics/Services/SessionDataStore.swift
@@ -803,12 +803,14 @@ final class SessionDataStore: ObservableObject {
         var buckets: [Date: PeriodStats] = [:]
         var periodSessionIds: [Date: Set<String>] = [:]
         var periodModelSessionIds: [Date: [String: Set<String>]] = [:]
+        let originBySessionId = Self.originBySessionId(snapshot.sessions)
 
         let resetDate = snapshot.weeklyResetDate
         // Use fiveMinSlices when weekly period has non-midnight boundary for accurate attribution
         let useFineSlices = snapshot.selectedPeriod == .weekly && resetDate != nil
 
         for (sessionId, stats) in snapshot.parsedStats {
+            let origin = originBySessionId[sessionId] ?? .claudeCode
             let slices = useFineSlices ? stats.fiveMinSlices : stats.daySlices
             if !slices.isEmpty {
                 for (sliceStart, slice) in slices {
@@ -820,7 +822,7 @@ final class SessionDataStore: ObservableObject {
                             chartLabel: snapshot.selectedPeriod.chartLabel(for: periodStart, weeklyResetDate: resetDate)
                         )
                     }
-                    buckets[periodStart]?.accumulate(daySlice: slice)
+                    buckets[periodStart]?.accumulate(daySlice: slice, origin: origin)
                     periodSessionIds[periodStart, default: []].insert(sessionId)
                     for model in slice.modelBreakdown.keys {
                         var modelDict = periodModelSessionIds[periodStart] ?? [:]
@@ -842,7 +844,7 @@ final class SessionDataStore: ObservableObject {
                         chartLabel: snapshot.selectedPeriod.chartLabel(for: periodStart, weeklyResetDate: resetDate)
                     )
                 }
-                buckets[periodStart]?.accumulate(stats: stats)
+                buckets[periodStart]?.accumulate(stats: stats, origin: origin)
                 periodSessionIds[periodStart, default: []].insert(sessionId)
                 for model in stats.modelBreakdown.keys {
                     var modelDict = periodModelSessionIds[periodStart] ?? [:]
@@ -901,10 +903,12 @@ final class SessionDataStore: ObservableObject {
         let label = snapshot.allTimeLabel
         var agg = PeriodStats(period: Date.distantPast, periodLabel: label, chartLabel: label)
         var modelSessionIds: [String: Set<String>] = [:]
+        let originBySessionId = originBySessionId(snapshot.sessions)
 
         for (sessionId, stats) in snapshot.parsedStats {
+            let origin = originBySessionId[sessionId] ?? .claudeCode
             if stats.fiveMinSlices.isEmpty {
-                agg.accumulate(stats: stats)
+                agg.accumulate(stats: stats, origin: origin)
                 for model in stats.modelBreakdown.keys {
                     modelSessionIds[model, default: []].insert(sessionId)
                 }
@@ -913,7 +917,7 @@ final class SessionDataStore: ObservableObject {
                 }
             } else {
                 for (_, slice) in stats.fiveMinSlices {
-                    agg.accumulate(daySlice: slice)
+                    agg.accumulate(daySlice: slice, origin: origin)
                     for model in slice.modelBreakdown.keys {
                         modelSessionIds[model, default: []].insert(sessionId)
                     }
@@ -943,6 +947,15 @@ final class SessionDataStore: ObservableObject {
             availableHeatmapYears: allTimeAgg.availableYears,
             topProjects: allTimeAgg.topProjects
         )
+    }
+
+    /// Map each session id to its origin (Claude Code vs Cowork), derived from
+    /// the transcript path. Built once per rebucket so the per-session lookup
+    /// inside the aggregation loop stays O(1).
+    private nonisolated static func originBySessionId(_ sessions: [Session]) -> [String: SessionOrigin] {
+        sessions.reduce(into: [:]) { map, session in
+            map[session.id] = SessionOrigin.of(session)
+        }
     }
 
     /// Pure model-usage rollup across periods; static so both

--- a/ClaudeStatistics/ViewModels/SessionViewModel.swift
+++ b/ClaudeStatistics/ViewModels/SessionViewModel.swift
@@ -15,7 +15,13 @@ struct ProjectGroup: Identifiable {
 
     var displayName: String {
         let path = resolvedPath
-        return (path as NSString).lastPathComponent
+        let name = (path as NSString).lastPathComponent
+        // Cowork sessions group under an opaque sandbox path; prefix them so
+        // they read as Cowork in every project breakdown.
+        if SessionOrigin.of(filePath: path) == .cowork {
+            return "\(SessionOrigin.cowork.displayName): \(name)"
+        }
+        return name
     }
 
     var shortPath: String {

--- a/ClaudeStatistics/Views/Statistics/PeriodDetailView.swift
+++ b/ClaudeStatistics/Views/Statistics/PeriodDetailView.swift
@@ -66,6 +66,23 @@ struct PeriodDetailView: View {
                         }
                     }
 
+                    // 1b. Source split — Cowork (Claude Desktop) vs Claude Code.
+                    // Only shown when Cowork usage exists in this period.
+                    if stat.hasCoworkUsage {
+                        SectionCard {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Label("Source", systemImage: "person.2")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                sourceRow(name: SessionOrigin.claudeCode.displayName,
+                                          cost: stat.claudeCodeCost, tokens: stat.claudeCodeTokens, total: stat.totalCost)
+                                sourceRow(name: SessionOrigin.cowork.displayName,
+                                          cost: stat.coworkCost, tokens: stat.coworkTokens, total: stat.totalCost)
+                            }
+                        }
+                    }
+
                     // 2. Trend chart
                     SectionCard {
                         VStack(spacing: 8) {
@@ -151,6 +168,43 @@ struct PeriodDetailView: View {
                 .font(.system(size: 14, weight: .semibold, design: .monospaced))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// One row of the Cowork-vs-Claude-Code source split: name, a cost-share
+    /// bar, the share %, the token count, and the dollar cost.
+    private func sourceRow(name: String, cost: Double, tokens: Int, total: Double) -> some View {
+        let fraction = total > 0 ? max(0, min(1, cost / total)) : 0
+        return HStack(spacing: 8) {
+            Text(name)
+                .font(.system(size: 11, weight: .medium))
+                .frame(width: 92, alignment: .leading)
+                .lineLimit(1)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.secondary.opacity(0.15))
+                    Capsule().fill(Color.accentColor.opacity(0.7))
+                        .frame(width: max(2, geo.size.width * fraction))
+                }
+            }
+            .frame(height: 6)
+            Text("\(Int((fraction * 100).rounded()))%")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 34, alignment: .trailing)
+            Text(Self.formatTokens(tokens))
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 50, alignment: .trailing)
+            Text(formatCost(cost))
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .frame(width: 62, alignment: .trailing)
+        }
+    }
+
+    private static func formatTokens(_ count: Int) -> String {
+        if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
+        if count >= 1_000 { return String(format: "%.0fk", Double(count) / 1_000) }
+        return "\(count)"
     }
 
     private func metricWithDelta<Content: View>(delta: Double?, isInverse: Bool, @ViewBuilder content: () -> Content) -> some View {


### PR DESCRIPTION
## The gap

The token / cost **statistics** (daily, monthly, all-time) are computed locally by scanning `~/.claude/projects`. But **Cowork** (Claude Desktop's "local agent mode") runs a *sandboxed* Claude Code whose `~/.claude` is redirected into the desktop app's per-session workspace, so its transcripts live at:

```
~/Library/Application Support/Claude/local-agent-mode-sessions/
  <workspace>/<session>/local_<id>/.claude/projects/<proj>/<uuid>.jsonl
```

`SessionScanner` only ever walked `<claudeConfigDir>/projects`, so **none of that usage was counted** — every Cowork token and dollar was silently missing from the statistics. (The 5h / 7d **quota** is unaffected: it comes from `api.anthropic.com/.../oauth/usage`, which is account-level and already aggregates Cowork — there's even a `seven_day_cowork` field.)

The transcripts are standard Claude Code JSONL with full `usage` / `model` / `timestamp`, so the existing `TranscriptParser` parses them unchanged — they just weren't being discovered.

## The change

- **`SessionScanner.scanCoworkSessions()`** — walk the fixed Cowork structure above and fold the main transcripts into the same scan results. It deliberately skips `outputs/`, `audit.jsonl`, and `subagents/*.jsonl`, so it picks exactly the main transcripts (the same set the regular scanner would pick under `~/.claude/projects`) — no double counting. The per-file `Session` construction (size floor, subagent-size rollup, cwd read) is factored into a shared `makeSession(...)` used by both scans.
- **`SessionOrigin`** (new) — classifies a session as `.claudeCode` or `.cowork` from its transcript path. No schema change to the SDK `Session` (plugins construct it; keeping its ABI stable).
- **`PeriodStats` source split** — `accumulate(...)` gains an `origin` parameter (defaulted) and tracks `coworkCost` / `coworkTokens` / `coworkMessageCount` as a subset of the totals; `SessionDataStore.computeRebucket` / `computeAllTimeRebucket` look up each session's origin and pass it through.
- **`PeriodDetailView`** — a small "Source" card (only shown when Cowork usage exists in the period) renders the **Cowork vs Claude Code** split with a cost-share bar, %, token count, and dollar cost.
- **`CompositeSessionWatcher`** (new) + `ClaudeProvider.makeWatcher` — also FSEvents-watch the Cowork tree (filtered to real transcripts) so Cowork usage updates live, not just on relaunch.
- **`ProjectGroup.displayName`** — Cowork project groups read as `Cowork: <name>` instead of an opaque sandbox path.

## Result

Built and installed locally, then read the app's own parsed-stats cache (`session_cache` in `data.db`): the running app now ingests **67 Cowork sessions** it previously ignored — **~354M tokens** (opus-4-7, sonnet-4-6, opus-4-8, fable-5, haiku-4-5) that used to be counted as zero. App launches healthy; the scan walk was independently verified to find exactly the main transcripts with no audit/subagent double-counting.

Notes for review:
- The "Source" / labels use literal strings (`Source`, `Cowork`, `Claude Code`) — happy to route them through the localization catalog if you prefer.
- Origin is derived from the path rather than a new `Session` field, specifically to avoid changing the SDK struct that the Codex/Gemini plugins construct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)