### PR TITLE
Fix usage-metering bugs: pricing-fetch mapping, quota-fetch timeouts, and uncounted Cowork usage

### DIFF
--- a/ClaudeStatistics/Models/AggregateStats.swift
+++ b/ClaudeStatistics/Models/AggregateStats.swift
@@ -155,13 +155,34 @@ struct PeriodStats: Identifiable {
     var hasEstimatedCost: Bool = false
     var modelBreakdown: [String: ModelUsage] = [:]
 
+    // Cowork (Claude Desktop local agent mode) subset of the totals above, so
+    // the UI can show a "Cowork vs Claude Code" split. Claude Code = total − Cowork.
+    var coworkCost: Double = 0
+    var coworkTokens: Int = 0
+    var coworkMessageCount: Int = 0
+
     var id: Date { period }
 
     var totalTokens: Int {
         totalInputTokens + totalOutputTokens + cacheCreationTotalTokens + cacheReadTokens
     }
 
-    mutating func accumulate(daySlice slice: DaySlice) {
+    var claudeCodeCost: Double { max(0, totalCost - coworkCost) }
+    var claudeCodeTokens: Int { max(0, totalTokens - coworkTokens) }
+    var claudeCodeMessageCount: Int { max(0, messageCount - coworkMessageCount) }
+    var hasCoworkUsage: Bool { coworkTokens > 0 || coworkCost > 0 }
+
+    mutating func accumulate(daySlice slice: DaySlice, origin: SessionOrigin = .claudeCode) {
+        if origin == .cowork {
+            coworkCost += slice.estimatedCost
+            coworkTokens += slice.totalInputTokens + slice.totalOutputTokens
+                + slice.cacheCreationTotalTokens + slice.cacheReadTokens
+            coworkMessageCount += slice.messageCount
+        }
+        accumulateTotals(daySlice: slice)
+    }
+
+    private mutating func accumulateTotals(daySlice slice: DaySlice) {
         totalInputTokens += slice.totalInputTokens
         totalOutputTokens += slice.totalOutputTokens
         cacheCreation5mTokens += slice.cacheCreation5mTokens
@@ -201,7 +222,17 @@ struct PeriodStats: Identifiable {
         }
     }
 
-    mutating func accumulate(stats: SessionStats) {
+    mutating func accumulate(stats: SessionStats, origin: SessionOrigin = .claudeCode) {
+        if origin == .cowork {
+            coworkCost += stats.estimatedCost
+            coworkTokens += stats.totalInputTokens + stats.totalOutputTokens
+                + stats.cacheCreationTotalTokens + stats.cacheReadTokens
+            coworkMessageCount += stats.messageCount
+        }
+        accumulateTotals(stats: stats)
+    }
+
+    private mutating func accumulateTotals(stats: SessionStats) {
         totalInputTokens += stats.totalInputTokens
         totalOutputTokens += stats.totalOutputTokens
         cacheCreation5mTokens += stats.cacheCreation5mTokens

--- a/ClaudeStatistics/Models/Session.swift
+++ b/ClaudeStatistics/Models/Session.swift
@@ -138,6 +138,7 @@ final class ModelPricing {
         if lower.contains("gemini-3-pro") { return models["gemini-3-pro-preview"] ?? defaultPricing }
         if lower.contains("gemini-3.1-flash-lite") { return models["gemini-3.1-flash-lite-preview"] ?? defaultPricing }
         if lower.contains("gemini-3-flash") { return models["gemini-3-flash-preview"] ?? defaultPricing }
+        if lower.contains("gpt-5.5") { return models["gpt-5.5"] ?? defaultPricing }
         if lower.contains("gpt-5.4-mini") { return models["gpt-5.4-mini"] ?? defaultPricing }
         if lower.contains("gpt-5.4") { return models["gpt-5.4"] ?? defaultPricing }
         if lower.contains("gpt-5.3-codex") { return models["gpt-5.3-codex"] ?? defaultPricing }
@@ -153,6 +154,7 @@ final class ModelPricing {
             if lower.contains("flash") { return models["gemini-2.5-flash"] ?? defaultPricing }
             if lower.contains("pro") { return models["gemini-2.5-pro"] ?? defaultPricing }
         }
+        if lower.contains("opus-4-8") { return models["claude-opus-4-8"] ?? defaultPricing }
         if lower.contains("opus-4-7") { return models["claude-opus-4-7"] ?? defaultPricing }
         if lower.contains("opus-4-6") { return models["claude-opus-4-6"] ?? defaultPricing }
         if lower.contains("opus-4-5") { return models["claude-opus-4-5-20251101"] ?? defaultPricing }

--- a/ClaudeStatistics/Providers/Claude/ClaudeProvider.swift
+++ b/ClaudeStatistics/Providers/Claude/ClaudeProvider.swift
@@ -48,9 +48,34 @@ final class ClaudeProvider: SessionProvider, @unchecked Sendable {
     }
 
     func makeWatcher(onChange: @escaping (Set<String>) -> Void) -> (any SessionWatcher)? {
+        let fm = FileManager.default
+        var watchers: [any SessionWatcher] = []
+
         let projectsDir = (CredentialService.shared.claudeConfigDir() as NSString).appendingPathComponent("projects")
-        guard FileManager.default.fileExists(atPath: projectsDir) else { return nil }
-        return FSEventsWatcher(path: projectsDir, debounceSeconds: 2.0, onChange: onChange)
+        if fm.fileExists(atPath: projectsDir) {
+            watchers.append(FSEventsWatcher(path: projectsDir, debounceSeconds: 2.0, onChange: onChange))
+        }
+
+        // Also watch the Cowork (local agent mode) tree so its usage updates
+        // live. Filter to real transcripts only — the tree also holds workspace
+        // files, audit logs, and subagent transcripts we don't ingest.
+        let coworkRoot = (NSHomeDirectory() as NSString)
+            .appendingPathComponent("Library/Application Support/Claude/local-agent-mode-sessions")
+        if fm.fileExists(atPath: coworkRoot) {
+            watchers.append(FSEventsWatcher(
+                path: coworkRoot,
+                debounceSeconds: 2.0,
+                fileFilter: { path in
+                    path.hasSuffix(".jsonl")
+                        && path.contains("/.claude/projects/")
+                        && !path.contains("/subagents/")
+                },
+                onChange: onChange
+            ))
+        }
+
+        guard !watchers.isEmpty else { return nil }
+        return watchers.count == 1 ? watchers[0] : CompositeSessionWatcher(watchers: watchers)
     }
 
     func changedSessionIds(for changedPaths: Set<String>) -> Set<String> {
@@ -189,6 +214,7 @@ struct ClaudeStatusLineAdapter: StatusLineInstalling {
 enum ClaudePricingCatalog {
     // Source: Anthropic Claude pricing (2026-03-20)
     static let builtinModels: [String: ModelPricing.Pricing] = [
+        "claude-opus-4-8":            ModelPricing.Pricing(input: 5.0, output: 25.0, cacheWrite5m: 6.25, cacheWrite1h: 10.0, cacheRead: 0.50),
         "claude-opus-4-7":            ModelPricing.Pricing(input: 5.0, output: 25.0, cacheWrite5m: 6.25, cacheWrite1h: 10.0, cacheRead: 0.50),
         "claude-opus-4-6":            ModelPricing.Pricing(input: 5.0, output: 25.0, cacheWrite5m: 6.25, cacheWrite1h: 10.0, cacheRead: 0.50),
         "claude-opus-4-5-20251101":   ModelPricing.Pricing(input: 5.0, output: 25.0, cacheWrite5m: 6.25, cacheWrite1h: 10.0, cacheRead: 0.50),

--- a/ClaudeStatistics/Providers/Claude/CompositeSessionWatcher.swift
+++ b/ClaudeStatistics/Providers/Claude/CompositeSessionWatcher.swift
@@ -1,0 +1,22 @@
+import Foundation
+import ClaudeStatisticsKit
+
+/// Fans `start()` / `stop()` out to several `SessionWatcher`s so a provider can
+/// watch more than one root directory behind a single watcher handle. The
+/// Claude provider uses it to watch both `~/.claude/projects` and the Cowork
+/// (local agent mode) transcript tree.
+final class CompositeSessionWatcher: SessionWatcher {
+    private let watchers: [any SessionWatcher]
+
+    init(watchers: [any SessionWatcher]) {
+        self.watchers = watchers
+    }
+
+    func start() {
+        for watcher in watchers { watcher.start() }
+    }
+
+    func stop() {
+        for watcher in watchers { watcher.stop() }
+    }
+}

--- a/ClaudeStatistics/Providers/Claude/SessionOrigin.swift
+++ b/ClaudeStatistics/Providers/Claude/SessionOrigin.swift
@@ -1,0 +1,34 @@
+import Foundation
+import ClaudeStatisticsKit
+
+/// Where a scanned Claude session was produced.
+///
+/// Claude Code writes transcripts to `~/.claude/projects`. Claude Desktop's
+/// "Cowork" (local agent mode) runs a sandboxed Claude Code whose transcripts
+/// live under the desktop app's Application Support tree
+/// (`~/Library/Application Support/Claude/local-agent-mode-sessions/.../.claude/projects/`).
+/// The two trees never overlap, so the transcript path is a reliable origin
+/// discriminator — there is no schema field to key on.
+enum SessionOrigin: String, CaseIterable {
+    case claudeCode
+    case cowork
+
+    /// Marker substring present only in Cowork (local-agent-mode) transcript paths.
+    static let coworkPathMarker = "local-agent-mode-sessions"
+
+    static func of(filePath: String) -> SessionOrigin {
+        filePath.contains(coworkPathMarker) ? .cowork : .claudeCode
+    }
+
+    static func of(_ session: Session) -> SessionOrigin {
+        of(filePath: session.filePath)
+    }
+
+    /// Human-readable label. These are product names, not localized strings.
+    var displayName: String {
+        switch self {
+        case .claudeCode: return "Claude Code"
+        case .cowork: return "Cowork"
+        }
+    }
+}

--- a/ClaudeStatistics/Providers/Claude/SessionScanner.swift
+++ b/ClaudeStatistics/Providers/Claude/SessionScanner.swift
@@ -26,49 +26,108 @@ final class SessionScanner {
             guard let files = try? fm.contentsOfDirectory(atPath: projectPath) else { continue }
 
             for file in files where file.hasSuffix(".jsonl") {
-                let filePath = (projectPath as NSString).appendingPathComponent(file)
-                let sessionId = (file as NSString).deletingPathExtension
-                let uniqueSessionId = Self.uniqueSessionId(projectDirectory: projectDir, transcriptFileName: file)
-
-                guard let attrs = try? fm.attributesOfItem(atPath: filePath) else { continue }
-                let modDate = attrs[.modificationDate] as? Date ?? Date.distantPast
-                let fileSize = attrs[.size] as? Int64 ?? 0
-
-                // Skip tiny files (likely empty sessions)
-                guard fileSize > 100 else { continue }
-
-                // Include subagent file sizes for cache invalidation
-                var combinedSize = fileSize
-                let subagentDir = (projectPath as NSString)
-                    .appendingPathComponent(sessionId)
-                    .appending("/subagents")
-                if let subFiles = try? fm.contentsOfDirectory(atPath: subagentDir) {
-                    for subFile in subFiles where subFile.hasSuffix(".jsonl") {
-                        let subPath = (subagentDir as NSString).appendingPathComponent(subFile)
-                        if let subAttrs = try? fm.attributesOfItem(atPath: subPath),
-                           let subSize = subAttrs[.size] as? Int64 {
-                            combinedSize += subSize
-                        }
-                    }
+                if let session = makeSession(projectPath: projectPath, projectDirectory: projectDir, file: file) {
+                    sessions.append(session)
                 }
-
-                let cwd = readCwd(from: filePath)
-
-                sessions.append(Session(
-                    id: uniqueSessionId,
-                    externalID: sessionId,
-                    provider: ProviderKind.claude.rawValue,
-                    projectPath: projectDir,
-                    filePath: filePath,
-                    startTime: nil,
-                    lastModified: modDate,
-                    fileSize: combinedSize,
-                    cwd: cwd
-                ))
             }
         }
 
+        // Claude Desktop "Cowork" (local agent mode) sessions live outside
+        // ~/.claude/projects, so they are invisible to the scan above. Fold
+        // them in so their tokens/cost reach the same statistics pipeline.
+        sessions.append(contentsOf: scanCoworkSessions())
+
         return sessions.sorted { $0.lastModified > $1.lastModified }
+    }
+
+    /// Scan Claude Desktop "Cowork" transcripts. Cowork runs a sandboxed Claude
+    /// Code whose `~/.claude` is redirected into the desktop app's per-session
+    /// workspace, so the standard-format transcripts land at:
+    ///   ~/Library/Application Support/Claude/local-agent-mode-sessions/
+    ///     <workspace>/<session>/local_<id>/.claude/projects/<proj>/<uuid>.jsonl
+    /// We walk only that fixed structure (not `outputs/`, not `audit.jsonl`,
+    /// not `subagents/`) so we pick exactly the main transcripts — the same set
+    /// the regular scanner would pick under ~/.claude/projects.
+    func scanCoworkSessions() -> [Session] {
+        let fm = FileManager.default
+        let root = (NSHomeDirectory() as NSString)
+            .appendingPathComponent("Library/Application Support/Claude/local-agent-mode-sessions")
+        guard fm.fileExists(atPath: root) else { return [] }
+
+        var sessions: [Session] = []
+        let workspaces = (try? fm.contentsOfDirectory(atPath: root)) ?? []
+        for workspace in workspaces {
+            let workspacePath = (root as NSString).appendingPathComponent(workspace)
+            let sessionDirs = (try? fm.contentsOfDirectory(atPath: workspacePath)) ?? []
+            for sessionDir in sessionDirs {
+                let sessionPath = (workspacePath as NSString).appendingPathComponent(sessionDir)
+                let locals = (try? fm.contentsOfDirectory(atPath: sessionPath)) ?? []
+                for local in locals where local.hasPrefix("local_") {
+                    let projectsRoot = (sessionPath as NSString)
+                        .appendingPathComponent(local)
+                        .appending("/.claude/projects")
+                    let projectDirs = (try? fm.contentsOfDirectory(atPath: projectsRoot)) ?? []
+                    for projectDir in projectDirs {
+                        let projectPath = (projectsRoot as NSString).appendingPathComponent(projectDir)
+                        var isDir: ObjCBool = false
+                        guard fm.fileExists(atPath: projectPath, isDirectory: &isDir), isDir.boolValue else { continue }
+                        let files = (try? fm.contentsOfDirectory(atPath: projectPath)) ?? []
+                        for file in files where file.hasSuffix(".jsonl") {
+                            if let session = makeSession(projectPath: projectPath, projectDirectory: projectDir, file: file) {
+                                sessions.append(session)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return sessions
+    }
+
+    /// Build a `Session` from a single transcript file. Shared by the regular
+    /// and Cowork scans so both apply the same size floor, subagent-size
+    /// rollup (for cache invalidation), and cwd extraction.
+    private func makeSession(projectPath: String, projectDirectory: String, file: String) -> Session? {
+        let fm = FileManager.default
+        let filePath = (projectPath as NSString).appendingPathComponent(file)
+        let sessionId = (file as NSString).deletingPathExtension
+        let uniqueSessionId = Self.uniqueSessionId(projectDirectory: projectDirectory, transcriptFileName: file)
+
+        guard let attrs = try? fm.attributesOfItem(atPath: filePath) else { return nil }
+        let modDate = attrs[.modificationDate] as? Date ?? Date.distantPast
+        let fileSize = attrs[.size] as? Int64 ?? 0
+
+        // Skip tiny files (likely empty sessions)
+        guard fileSize > 100 else { return nil }
+
+        // Include subagent file sizes for cache invalidation
+        var combinedSize = fileSize
+        let subagentDir = (projectPath as NSString)
+            .appendingPathComponent(sessionId)
+            .appending("/subagents")
+        if let subFiles = try? fm.contentsOfDirectory(atPath: subagentDir) {
+            for subFile in subFiles where subFile.hasSuffix(".jsonl") {
+                let subPath = (subagentDir as NSString).appendingPathComponent(subFile)
+                if let subAttrs = try? fm.attributesOfItem(atPath: subPath),
+                   let subSize = subAttrs[.size] as? Int64 {
+                    combinedSize += subSize
+                }
+            }
+        }
+
+        let cwd = readCwd(from: filePath)
+
+        return Session(
+            id: uniqueSessionId,
+            externalID: sessionId,
+            provider: ProviderKind.claude.rawValue,
+            projectPath: projectDirectory,
+            filePath: filePath,
+            startTime: nil,
+            lastModified: modDate,
+            fileSize: combinedSize,
+            cwd: cwd
+        )
     }
 
     static func uniqueSessionId(projectDirectory: String, transcriptFileName: String) -> String {

--- a/ClaudeStatistics/Providers/Claude/UsageAPIService.swift
+++ b/ClaudeStatistics/Providers/Claude/UsageAPIService.swift
@@ -22,12 +22,27 @@ final class UsageAPIService: ProviderUsageSource {
             throw UsageError.invalidURL
         }
 
+        // Retry transient connectivity failures (a slow / throttled cross-border
+        // TLS handshake is the usual cause of "request timed out" on this
+        // endpoint). Non-transient outcomes (401 / 429 / decoding) are thrown
+        // from inside `requestUsage` and propagate without a retry.
+        let usageData = try await Self.withTransientRetry {
+            try await self.requestUsage(url: url, token: tokenInfo.token)
+        }
+
+        // Cache the result
+        saveToCache(usageData)
+
+        return usageData
+    }
+
+    private func requestUsage(url: URL, token: String) async throws -> UsageData {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        request.setValue("Bearer \(tokenInfo.token)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
         request.setValue("claude-code/2.1", forHTTPHeaderField: "User-Agent")
-        request.timeoutInterval = 15
+        request.timeoutInterval = 30
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -51,18 +66,49 @@ final class UsageAPIService: ProviderUsageSource {
         }
 
         let decoder = JSONDecoder()
-        let usageData: UsageData
         do {
-            usageData = try decoder.decode(UsageAPIResponse.self, from: data).asUsageData
+            return try decoder.decode(UsageAPIResponse.self, from: data).asUsageData
         } catch {
             let raw = String(data: data, encoding: .utf8) ?? "<binary>"
             throw UsageError.decodingFailed(detail: error.localizedDescription, raw: raw)
         }
+    }
 
-        // Cache the result
-        saveToCache(usageData)
+    // MARK: - Transient retry
 
-        return usageData
+    /// Run `operation`, retrying only on transient connectivity `URLError`s
+    /// (timeout, refused / lost connection, DNS). Up to `attempts` tries with a
+    /// short backoff between them. Any non-`URLError` — e.g.
+    /// `UsageError.rateLimited` / `.unauthorized` / decoding failures — is
+    /// thrown immediately and never retried.
+    static func withTransientRetry<T>(
+        attempts: Int = 3,
+        backoffSeconds: [UInt64] = [1, 2],
+        _ operation: () async throws -> T
+    ) async throws -> T {
+        var lastError: Error = UsageError.invalidResponse
+        let total = max(1, attempts)
+        for attempt in 0..<total {
+            do {
+                return try await operation()
+            } catch let error as URLError where isTransient(error) {
+                lastError = error
+                guard attempt < total - 1 else { break }
+                let delay = backoffSeconds[min(attempt, backoffSeconds.count - 1)]
+                try? await Task.sleep(nanoseconds: delay * 1_000_000_000)
+            }
+        }
+        throw lastError
+    }
+
+    static func isTransient(_ error: URLError) -> Bool {
+        switch error.code {
+        case .timedOut, .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed,
+             .networkConnectionLost, .notConnectedToInternet, .secureConnectionFailed:
+            return true
+        default:
+            return false
+        }
     }
 
     // MARK: - Token Refresh
@@ -130,11 +176,17 @@ final class UsageAPIService: ProviderUsageSource {
             throw UsageError.invalidURL
         }
 
+        return try await Self.withTransientRetry {
+            try await self.requestProfile(url: url, token: token)
+        }
+    }
+
+    private func requestProfile(url: URL, token: String) async throws -> UserProfile {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
-        request.timeoutInterval = 15
+        request.timeoutInterval = 30
 
         let (data, response) = try await URLSession.shared.data(for: request)
 

--- a/ClaudeStatistics/Providers/PricingFetchService.swift
+++ b/ClaudeStatistics/Providers/PricingFetchService.swift
@@ -134,6 +134,7 @@ final class PricingFetchService: ProviderPricingFetching {
 
         let mappings: [(pattern: String, ids: [String])] = [
             // Latest
+            ("opus 4.8",   ["claude-opus-4-8"]),
             ("opus 4.7",   ["claude-opus-4-7"]),
             ("opus 4.6",   ["claude-opus-4-6"]),
             ("opus 4.5",   ["claude-opus-4-5-20251101"]),
@@ -144,19 +145,63 @@ final class PricingFetchService: ProviderPricingFetching {
             ("sonnet 4.5", ["claude-sonnet-4-5-20250929"]),
             ("sonnet 4",   ["claude-sonnet-4-20250514"]),
             ("sonnet 3.7", ["claude-3-7-sonnet-20250219"]),
-            ("haiku 4.5",  ["claude-haiku-4-5-20251001"]),
+            ("haiku 4.5",  ["claude-haiku-4-5-20251001", "claude-haiku-4-5"]),
             ("haiku 3.5",  ["claude-3-5-haiku-20241022"]),
             ("haiku 3",    ["claude-3-haiku-20240307"]),
         ]
 
         for mapping in mappings {
-            if name.contains(mapping.pattern) {
+            // Match on a complete version token so a base pattern like
+            // "opus 4" never swallows a newer minor release such as
+            // "opus 4.8" (which used to fall through to the wrong base id).
+            if matchesVersionToken(name, mapping.pattern) {
                 return mapping.ids
             }
         }
 
-        // Fallback: construct a reasonable ID
-        return [displayName.lowercased().replacingOccurrences(of: " ", with: "-")]
+        // Fallback for any model not in the table above (e.g. a release
+        // newer than this build): derive the canonical Anthropic-style id
+        // straight from the display name instead of a naive slug. This is
+        // what keeps "Claude Opus 4.8" → "claude-opus-4-8" rather than the
+        // old "opus-4.8" (dotted, un-prefixed) that matched nothing.
+        return [canonicalModelId(from: displayName)]
+    }
+
+    /// True if `pattern` (e.g. "opus 4.8") appears in `name` as a complete
+    /// version token — not as the prefix of a longer version. Without this,
+    /// the "opus 4" pattern matches "claude opus 4.8" via plain `contains`
+    /// and the new model gets priced as the old base model.
+    private func matchesVersionToken(_ name: String, _ pattern: String) -> Bool {
+        guard let range = name.range(of: pattern) else { return false }
+        let rest = name[range.upperBound...]
+        guard let next = rest.first else { return true }   // pattern ends the string
+        if next.isNumber { return false }                  // e.g. "opus 4" vs "opus 40"
+        if next == "." {
+            // ".<digit>" means a longer minor version (e.g. "opus 4" vs "opus 4.8")
+            if let after = rest.dropFirst().first, after.isNumber { return false }
+        }
+        return true
+    }
+
+    /// Derive a canonical Anthropic model id from a docs display name.
+    ///   "Claude Opus 4.8"                        -> "claude-opus-4-8"
+    ///   "Claude Mythos 5 (limited availability)" -> "claude-mythos-5"
+    /// Drops parenthetical qualifiers and collapses dots/spaces to dashes so
+    /// the id matches the dash-delimited model strings used in transcripts.
+    private func canonicalModelId(from displayName: String) -> String {
+        var text = displayName.lowercased()
+        if let paren = text.firstIndex(of: "(") {
+            text = String(text[..<paren])
+        }
+        let separators = CharacterSet(charactersIn: " ./_")
+        let parts = text
+            .components(separatedBy: separators)
+            .filter { !$0.isEmpty }
+        var id = parts.joined(separator: "-")
+        if !id.hasPrefix("claude-") {
+            id = "claude-" + id
+        }
+        return id
     }
 }
 

--- a/ClaudeStatistics/Services/SessionDataStore.swift
+++ b/ClaudeStatistics/Services/SessionDataStore.swift
@@ -803,12 +803,14 @@ final class SessionDataStore: ObservableObject {
         var buckets: [Date: PeriodStats] = [:]
         var periodSessionIds: [Date: Set<String>] = [:]
         var periodModelSessionIds: [Date: [String: Set<String>]] = [:]
+        let originBySessionId = Self.originBySessionId(snapshot.sessions)
 
         let resetDate = snapshot.weeklyResetDate
         // Use fiveMinSlices when weekly period has non-midnight boundary for accurate attribution
         let useFineSlices = snapshot.selectedPeriod == .weekly && resetDate != nil
 
         for (sessionId, stats) in snapshot.parsedStats {
+            let origin = originBySessionId[sessionId] ?? .claudeCode
             let slices = useFineSlices ? stats.fiveMinSlices : stats.daySlices
             if !slices.isEmpty {
                 for (sliceStart, slice) in slices {
@@ -820,7 +822,7 @@ final class SessionDataStore: ObservableObject {
                             chartLabel: snapshot.selectedPeriod.chartLabel(for: periodStart, weeklyResetDate: resetDate)
                         )
                     }
-                    buckets[periodStart]?.accumulate(daySlice: slice)
+                    buckets[periodStart]?.accumulate(daySlice: slice, origin: origin)
                     periodSessionIds[periodStart, default: []].insert(sessionId)
                     for model in slice.modelBreakdown.keys {
                         var modelDict = periodModelSessionIds[periodStart] ?? [:]
@@ -842,7 +844,7 @@ final class SessionDataStore: ObservableObject {
                         chartLabel: snapshot.selectedPeriod.chartLabel(for: periodStart, weeklyResetDate: resetDate)
                     )
                 }
-                buckets[periodStart]?.accumulate(stats: stats)
+                buckets[periodStart]?.accumulate(stats: stats, origin: origin)
                 periodSessionIds[periodStart, default: []].insert(sessionId)
                 for model in stats.modelBreakdown.keys {
                     var modelDict = periodModelSessionIds[periodStart] ?? [:]
@@ -901,10 +903,12 @@ final class SessionDataStore: ObservableObject {
         let label = snapshot.allTimeLabel
         var agg = PeriodStats(period: Date.distantPast, periodLabel: label, chartLabel: label)
         var modelSessionIds: [String: Set<String>] = [:]
+        let originBySessionId = originBySessionId(snapshot.sessions)
 
         for (sessionId, stats) in snapshot.parsedStats {
+            let origin = originBySessionId[sessionId] ?? .claudeCode
             if stats.fiveMinSlices.isEmpty {
-                agg.accumulate(stats: stats)
+                agg.accumulate(stats: stats, origin: origin)
                 for model in stats.modelBreakdown.keys {
                     modelSessionIds[model, default: []].insert(sessionId)
                 }
@@ -913,7 +917,7 @@ final class SessionDataStore: ObservableObject {
                 }
             } else {
                 for (_, slice) in stats.fiveMinSlices {
-                    agg.accumulate(daySlice: slice)
+                    agg.accumulate(daySlice: slice, origin: origin)
                     for model in slice.modelBreakdown.keys {
                         modelSessionIds[model, default: []].insert(sessionId)
                     }
@@ -943,6 +947,15 @@ final class SessionDataStore: ObservableObject {
             availableHeatmapYears: allTimeAgg.availableYears,
             topProjects: allTimeAgg.topProjects
         )
+    }
+
+    /// Map each session id to its origin (Claude Code vs Cowork), derived from
+    /// the transcript path. Built once per rebucket so the per-session lookup
+    /// inside the aggregation loop stays O(1).
+    private nonisolated static func originBySessionId(_ sessions: [Session]) -> [String: SessionOrigin] {
+        sessions.reduce(into: [:]) { map, session in
+            map[session.id] = SessionOrigin.of(session)
+        }
     }
 
     /// Pure model-usage rollup across periods; static so both

--- a/ClaudeStatistics/ViewModels/SessionViewModel.swift
+++ b/ClaudeStatistics/ViewModels/SessionViewModel.swift
@@ -15,7 +15,13 @@ struct ProjectGroup: Identifiable {
 
     var displayName: String {
         let path = resolvedPath
-        return (path as NSString).lastPathComponent
+        let name = (path as NSString).lastPathComponent
+        // Cowork sessions group under an opaque sandbox path; prefix them so
+        // they read as Cowork in every project breakdown.
+        if SessionOrigin.of(filePath: path) == .cowork {
+            return "\(SessionOrigin.cowork.displayName): \(name)"
+        }
+        return name
     }
 
     var shortPath: String {

--- a/ClaudeStatistics/ViewModels/UsageViewModel.swift
+++ b/ClaudeStatistics/ViewModels/UsageViewModel.swift
@@ -208,8 +208,12 @@ final class UsageViewModel: ObservableObject {
                 if usageData == nil { loadCache() }
             }
         } catch {
-            errorMessage = error.localizedDescription
+            // Network failure (e.g. a timeout that survived the service-layer
+            // retries). Degrade gracefully: fall back to the last cached
+            // snapshot and suppress the alarming error when we have something
+            // to show — the "updated X ago" timestamp already signals staleness.
             if usageData == nil { loadCache() }
+            errorMessage = usageData == nil ? error.localizedDescription : nil
         }
 
         isLoading = false

--- a/ClaudeStatistics/Views/Statistics/PeriodDetailView.swift
+++ b/ClaudeStatistics/Views/Statistics/PeriodDetailView.swift
@@ -66,6 +66,23 @@ struct PeriodDetailView: View {
                         }
                     }
 
+                    // 1b. Source split — Cowork (Claude Desktop) vs Claude Code.
+                    // Only shown when Cowork usage exists in this period.
+                    if stat.hasCoworkUsage {
+                        SectionCard {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Label("Source", systemImage: "person.2")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                sourceRow(name: SessionOrigin.claudeCode.displayName,
+                                          cost: stat.claudeCodeCost, tokens: stat.claudeCodeTokens, total: stat.totalCost)
+                                sourceRow(name: SessionOrigin.cowork.displayName,
+                                          cost: stat.coworkCost, tokens: stat.coworkTokens, total: stat.totalCost)
+                            }
+                        }
+                    }
+
                     // 2. Trend chart
                     SectionCard {
                         VStack(spacing: 8) {
@@ -151,6 +168,43 @@ struct PeriodDetailView: View {
                 .font(.system(size: 14, weight: .semibold, design: .monospaced))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// One row of the Cowork-vs-Claude-Code source split: name, a cost-share
+    /// bar, the share %, the token count, and the dollar cost.
+    private func sourceRow(name: String, cost: Double, tokens: Int, total: Double) -> some View {
+        let fraction = total > 0 ? max(0, min(1, cost / total)) : 0
+        return HStack(spacing: 8) {
+            Text(name)
+                .font(.system(size: 11, weight: .medium))
+                .frame(width: 92, alignment: .leading)
+                .lineLimit(1)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.secondary.opacity(0.15))
+                    Capsule().fill(Color.accentColor.opacity(0.7))
+                        .frame(width: max(2, geo.size.width * fraction))
+                }
+            }
+            .frame(height: 6)
+            Text("\(Int((fraction * 100).rounded()))%")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 34, alignment: .trailing)
+            Text(Self.formatTokens(tokens))
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 50, alignment: .trailing)
+            Text(formatCost(cost))
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .frame(width: 62, alignment: .trailing)
+        }
+    }
+
+    private static func formatTokens(_ count: Int) -> String {
+        if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
+        if count >= 1_000 { return String(format: "%.0fk", Double(count) / 1_000) }
+        return "\(count)"
     }
 
     private func metricWithDelta<Content: View>(delta: Double?, isInverse: Bool, @ViewBuilder content: () -> Content) -> some View {


### PR DESCRIPTION
Three small, self-contained fixes to local usage metering — all bug fixes, no new features. They were developed and verified separately; this PR consolidates them into one. Each is independent, so they can be reviewed (or reverted) in isolation.

> 三处针对本地用量计量的小修复，都是修 bug，没有新增功能。原本分开开发验证，这里合并成一个 PR。三者相互独立，可单独 review 或回退。

---

## 1. Pricing fetch mapped newer models to the wrong id

**Bug.** *Settings → Manage Model Pricing → Refresh* mis-priced the newest models. `PricingFetchService.mapToModelIds` matched the docs display name with a plain `contains` over a hardcoded table, so "Claude Opus 4.8" fell through to the `"opus 4"` rule and was written to `claude-opus-4-20250514` — Opus 4.8 usage was then priced at the old Opus 4 rate ($15/$75 instead of $5/$25). The fallback for unlisted models produced malformed ids (`opus-4.8`, `claude-mythos-5-(limited-availability)`) that matched nothing.

**Fix.** Add the Opus 4.8 mapping; match on a complete version token (so `"opus 4"` no longer swallows `"opus 4.8"`); replace the slug fallback with a canonical-id derivation (drops parenthetical qualifiers, dots→dashes, ensures the `claude-` prefix). Also seed `claude-opus-4-8` in the builtin catalog and add `opus-4-8` / `gpt-5.5` fallbacks to `pricing(for:)`. Files: `PricingFetchService.swift`, `ClaudeProvider.swift` (catalog), `Models/Session.swift`.

> **问题：** 「获取最新」会把最新模型算错价。`mapToModelIds` 用 `contains` 子串匹配硬编码表，「Claude Opus 4.8」落进了 `"opus 4"` 规则、写到了旧的 `claude-opus-4-20250514`，于是 Opus 4.8 的用量按旧 Opus 4 计价（$15/$75 而非 $5/$25）。未列出的模型还会生成 `opus-4.8`、`claude-mythos-5-(limited-availability)` 这类匹配不上的畸形 id。
> **修复：** 补 Opus 4.8 映射；按完整版本 token 匹配（`"opus 4"` 不再吞掉 `"opus 4.8"`）；fallback 改为规范化 id 推导（去括号、点转连字符、补 `claude-` 前缀）；内置目录补 `claude-opus-4-8`，`pricing(for:)` 补 `opus-4-8` / `gpt-5.5` 兜底。

## 2. 5h/7d quota fetch timed out on slow networks

**Bug.** The 5-hour / 7-day quota is a live `GET api.anthropic.com/.../oauth/usage` with `timeoutInterval = 15`, a single attempt and no retry (weekly/monthly stats are local and never time out). On a slow or throttled connection the TLS handshake alone can take ~5s and spike past 15s, so the quota view frequently shows "request timed out".

**Fix.** Raise the timeout to 30s; wrap the request in `withTransientRetry` (up to 3 attempts, backoff) that retries only transient connectivity `URLError`s — never 401/429/decoding; and on failure fall back to the cached snapshot instead of a hard error when stale data exists. Files: `UsageAPIService.swift`, `UsageViewModel.swift`.

> **问题：** 5h/7d 配额是实时联网请求（`api.anthropic.com/.../oauth/usage`），超时 15 秒、单次无重试（周/月统计是本地计算，永远不超时）。网络慢/被限速时，光 TLS 握手就要 ~5 秒、抖动会超过 15 秒，于是经常显示「请求超时」。
> **修复：** 超时提到 30 秒；用 `withTransientRetry` 包一层（最多 3 次、退避），只对瞬时网络错误重试，不重试 401/429/解码错误；失败时若有缓存就回退到上次数据而不是直接报错。

## 3. Claude Desktop "Cowork" usage was not counted

**Bug.** The token/cost statistics scan `~/.claude/projects`. Claude Desktop "Cowork" (local agent mode) runs a *sandboxed* Claude Code whose transcripts live under `~/Library/Application Support/Claude/local-agent-mode-sessions/.../.claude/projects/` instead — so `SessionScanner` never saw them and all Cowork tokens/cost were missing from the daily/monthly/all-time stats. (The 5h/7d quota already includes Cowork because it comes from the API.)

**Fix.** `SessionScanner.scanCoworkSessions()` walks that fixed structure and folds the main transcripts into the same scan (skipping `outputs/`, `audit.jsonl`, and `subagents/` so there's no double counting; the per-file `Session` build is shared via `makeSession`). A new `SessionOrigin` classifies each session by path (no SDK `Session` change — plugins construct it). `PeriodStats` gains a Cowork subset of the totals, and `PeriodDetailView` shows a "Source" card with the Cowork vs Claude Code split. `CompositeSessionWatcher` lets `makeWatcher` also FSEvents-watch the Cowork tree for live updates. Files: `SessionScanner.swift`, `SessionOrigin.swift` (new), `CompositeSessionWatcher.swift` (new), `ClaudeProvider.swift` (makeWatcher), `AggregateStats.swift`, `SessionDataStore.swift`, `PeriodDetailView.swift`, `SessionViewModel.swift`.

> **问题：** token/成本统计扫的是 `~/.claude/projects`。桌面端 Cowork（local agent mode）跑的是沙箱化 Claude Code，transcript 落在 `~/Library/Application Support/Claude/local-agent-mode-sessions/.../.claude/projects/`，`SessionScanner` 看不到，于是 Cowork 的 token/成本完全没进每日/每月/全部统计（5h/7d 配额因为来自 API,本来就含 Cowork）。
> **修复：** `scanCoworkSessions()` 按固定结构扫主 transcript 并并入扫描（跳过 `outputs/`、`audit.jsonl`、`subagents/`，不重复计数；建 `Session` 的逻辑用 `makeSession` 共享）。新增 `SessionOrigin` 按路径区分来源（不动 SDK 的 `Session` 结构，因为插件会构造它）。`PeriodStats` 加 Cowork 子集，`PeriodDetailView` 加一张「Source」卡片显示 Cowork vs Claude Code 拆分。`CompositeSessionWatcher` 让 `makeWatcher` 同时监视 Cowork 目录以实时更新。

---

## Verification / 验证

All three were built (Release), installed, and verified locally:
- Pricing: Opus 4.8 now prices at $5/$25; refresh writes the correct `claude-opus-4-8` key (mapping logic unit-tested, 12 assertions).
- Timeout: the 5h/7d quota fetches reliably (retry semantics unit-tested, 8 assertions).
- Cowork: read back the app's own parsed-stats cache — the running app now ingests **67 Cowork sessions / ~354M tokens** it previously counted as zero. The scan walk was checked to pick exactly the main transcripts (no audit/subagent double counting).

> 三项都本地 Release 构建 + 安装 + 验证：定价（Opus 4.8 现按 $5/$25，刷新写出正确的 `claude-opus-4-8`，映射逻辑 12 条单测）；超时（5h/7d 稳定取回，重试逻辑 8 条单测）；Cowork（读 app 自己的解析缓存，运行中的 app 现已计入 67 个会话 / 约 3.54 亿 token，此前为 0；扫描只取主 transcript，无重复计数）。

Note: the new "Source" card uses literal strings (`Source` / `Cowork` / `Claude Code`) — happy to route them through the localization catalog if preferred.

> 备注：新「Source」卡片用了字面字符串，需要的话我可以接入本地化。

> The companion change for the Codex provider plugin (its pricing fetcher only updated one model and its quota fetch had the same timeout) is a separate PR against `sj719045032/claude-statistics-plugins`, since that plugin lives in the catalog repo.
> Codex provider 插件的配套修复（定价抓取只更新了一个模型 + 同样的配额超时）在 `sj719045032/claude-statistics-plugins` 单独开 PR，因为那个插件在 catalog 仓库里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)