### PR TITLE
fix: make Claude pricing refresh version-safe

### DIFF
--- a/ClaudeStatistics.xcodeproj/project.pbxproj
+++ b/ClaudeStatistics.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		663E5EC2269BC72FDE27ADB5 /* WaitingInputCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8E853418A761D4E7EE20D9A /* WaitingInputCard.swift */; };
 		686EC93B311494291E5BCE75 /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1B839DD5F15A6A55AE3727 /* StatisticsView.swift */; };
 		68B755E9705080F12ABE613B /* TerminalContextEnriching.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54F5C781347553E20843025 /* TerminalContextEnriching.swift */; };
+		6AEDA946AA94FE9217071F42 /* PricingFetchServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FF156D3AF0B4CEE731144E /* PricingFetchServiceTests.swift */; };
 		6BA90267FC02621878E80D2A /* TrendChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDC6DF1C15355DC5AE2FCF9 /* TrendChartView.swift */; };
 		6C3E378F13580E74A2FC8A37 /* GeminiTestPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB942D2BB6BAD8CE785F2D /* GeminiTestPlaceholder.swift */; };
 		6CB15E196B0E4A38B471E499 /* ProviderDescriptor+Builtins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3763EF17B80F22CAE77EB0 /* ProviderDescriptor+Builtins.swift */; };
@@ -482,6 +483,7 @@
 		352BD87D6827246B00AD2179 /* DestructiveConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DestructiveConfirmation.swift; sourceTree = "<group>"; };
 		36F9BBB23CB057720EA99A7B /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		370D33AC086199C95EC1E2CD /* UsageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageData.swift; sourceTree = "<group>"; };
+		38FF156D3AF0B4CEE731144E /* PricingFetchServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricingFetchServiceTests.swift; sourceTree = "<group>"; };
 		393555CCEA3C235FDA1B435A /* ClaudeEndpointDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeEndpointDetector.swift; sourceTree = "<group>"; };
 		397B635FE9ED8F8B01A5AD1A /* SharePluginThemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePluginThemes.swift; sourceTree = "<group>"; };
 		3BCFE5BD947C85335BFC3783 /* ProviderUsagePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderUsagePresentation.swift; sourceTree = "<group>"; };
@@ -797,6 +799,7 @@
 				EB1DFC6E058CCC6A5552A8DD /* NotchStateMachineTests.swift */,
 				563272C01660D2FA4FBCBE13 /* NotificationTimerStoreTests.swift */,
 				86F1F7334EBE1509C248AE11 /* PermissionRequestRegistryTests.swift */,
+				38FF156D3AF0B4CEE731144E /* PricingFetchServiceTests.swift */,
 				8C94B6F432561CF7BD3D4FBD /* ProviderSessionDisplayFormatterTests.swift */,
 				1E5CDED000AE05D3ACDCD5D3 /* ProviderSessionRuntimeRetentionPolicyTests.swift */,
 				F3D7D7759B0623FB3A0EFA15 /* RuntimeSessionEventApplierTests.swift */,
@@ -1529,6 +1532,7 @@
 				22DCBBBC8A4BACCCD9C961F7 /* NotchStateMachineTests.swift in Sources */,
 				F508F785ACD950DAA8453487 /* NotificationTimerStoreTests.swift in Sources */,
 				1458F0ADB236E3CA0EDFAF4F /* PermissionRequestRegistryTests.swift in Sources */,
+				6AEDA946AA94FE9217071F42 /* PricingFetchServiceTests.swift in Sources */,
 				CE2A21F122971B1792CF548D /* ProviderSessionDisplayFormatterTests.swift in Sources */,
 				0A5CBEF5FE38C53D5B64A89F /* ProviderSessionRuntimeRetentionPolicyTests.swift in Sources */,
 				2605B8EACB69A1FD335D21AC /* RuntimeSessionEventApplierTests.swift in Sources */,

--- a/ClaudeStatistics/Providers/PricingFetchService.swift
+++ b/ClaudeStatistics/Providers/PricingFetchService.swift
@@ -7,7 +7,6 @@ final class PricingFetchService: ProviderPricingFetching {
     static let shared = PricingFetchService()
 
     private let pricingURL = "https://platform.claude.com/docs/en/about-claude/pricing"
-    private let minimumVersion = 4.5
 
     private init() {}
 
@@ -37,7 +36,7 @@ final class PricingFetchService: ProviderPricingFetching {
     /// Parse pricing from HTML table rows.
     /// The page renders as HTML with <tr>/<td> tags containing data like:
     ///   <td>Claude Opus 4.6</td><td>$5 / MTok</td><td>$6.25 / MTok</td>...
-    private func parsePricingFromHTML(_ html: String) throws -> [String: ModelPricing.Pricing] {
+    func parsePricingFromHTML(_ html: String) throws -> [String: ModelPricing.Pricing] {
         var results: [String: ModelPricing.Pricing] = [:]
 
         // Extract all <tr>...</tr> blocks that contain "Claude" and "MTok"
@@ -50,8 +49,8 @@ final class PricingFetchService: ProviderPricingFetching {
 
             // Must contain Claude model name and pricing
             guard rowHTML.contains("Claude") && rowHTML.contains("MTok") else { continue }
-            // Skip deprecated
-            guard !rowHTML.contains("deprecated") else { continue }
+            // Skip deprecated rows regardless of how the docs capitalize the label.
+            guard !rowHTML.lowercased().contains("deprecated") else { continue }
 
             // Extract all <td> cell contents
             let cells = extractTDContents(from: rowHTML)
@@ -75,7 +74,12 @@ final class PricingFetchService: ProviderPricingFetching {
             )
 
             for modelId in mapToModelIds(displayName: modelName) {
-                results[modelId] = pricing
+                // The docs can list the same model again for future, batch, or
+                // promotional pricing. The first six-column row is the current
+                // standard rate shown at the top of the page.
+                if results[modelId] == nil {
+                    results[modelId] = pricing
+                }
             }
         }
 
@@ -118,45 +122,55 @@ final class PricingFetchService: ProviderPricingFetching {
         return Double(cleaned)
     }
 
-    /// Check if model version is >= 4.5
-    private func shouldInclude(modelName: String) -> Bool {
-        for part in modelName.components(separatedBy: " ") {
-            if let version = Double(part), version >= minimumVersion {
-                return true
-            }
-        }
-        return false
-    }
-
     /// Map display names like "Claude Opus 4.6" to API model IDs
     private func mapToModelIds(displayName: String) -> [String] {
-        let name = displayName.lowercased()
-
-        let mappings: [(pattern: String, ids: [String])] = [
-            // Latest
-            ("opus 4.7",   ["claude-opus-4-7"]),
-            ("opus 4.6",   ["claude-opus-4-6"]),
-            ("opus 4.5",   ["claude-opus-4-5-20251101"]),
-            ("opus 4.1",   ["claude-opus-4-1-20250805"]),
-            ("opus 4",     ["claude-opus-4-20250514"]),
-            ("opus 3",     ["claude-3-opus-20240229"]),
-            ("sonnet 4.6", ["claude-sonnet-4-6"]),
-            ("sonnet 4.5", ["claude-sonnet-4-5-20250929"]),
-            ("sonnet 4",   ["claude-sonnet-4-20250514"]),
-            ("sonnet 3.7", ["claude-3-7-sonnet-20250219"]),
-            ("haiku 4.5",  ["claude-haiku-4-5-20251001"]),
-            ("haiku 3.5",  ["claude-3-5-haiku-20241022"]),
-            ("haiku 3",    ["claude-3-haiku-20240307"]),
+        let canonicalId = canonicalModelId(from: displayName)
+        let aliases: [String: [String]] = [
+            "claude-opus-4-5": ["claude-opus-4-5-20251101"],
+            "claude-opus-4-1": ["claude-opus-4-1-20250805"],
+            "claude-opus-4": ["claude-opus-4-20250514"],
+            "claude-opus-3": ["claude-3-opus-20240229"],
+            "claude-sonnet-4-5": ["claude-sonnet-4-5-20250929"],
+            "claude-sonnet-4": ["claude-sonnet-4-20250514"],
+            "claude-sonnet-3-7": ["claude-3-7-sonnet-20250219"],
+            "claude-haiku-4-5": ["claude-haiku-4-5", "claude-haiku-4-5-20251001"],
+            "claude-haiku-3-5": ["claude-3-5-haiku-20241022"],
+            "claude-haiku-3": ["claude-3-haiku-20240307"],
         ]
 
-        for mapping in mappings {
-            if name.contains(mapping.pattern) {
-                return mapping.ids
-            }
+        if let knownAliases = aliases[canonicalId] {
+            return [canonicalId] + knownAliases.filter { $0 != canonicalId }
+        }
+        return [canonicalId]
+    }
+
+    /// Derive a future-proof Anthropic model id from a docs display name.
+    /// Parenthetical availability notes are not part of the API model id.
+    private func canonicalModelId(from displayName: String) -> String {
+        var text = displayName.lowercased()
+        if let paren = text.firstIndex(of: "(") {
+            text = String(text[..<paren])
         }
 
-        // Fallback: construct a reasonable ID
-        return [displayName.lowercased().replacingOccurrences(of: " ", with: "-")]
+        // Pricing rows sometimes append availability dates without
+        // parentheses. Capture only the stable leading
+        // "Claude <family> <version>" name while preserving decimals.
+        if let regex = try? NSRegularExpression(pattern: #"^claude\s+([a-z0-9-]+)\s+([0-9]+(?:\.[0-9]+)?)"#),
+           let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+           let familyRange = Range(match.range(at: 1), in: text),
+           let versionRange = Range(match.range(at: 2), in: text) {
+            let family = text[familyRange]
+            let version = text[versionRange].replacingOccurrences(of: ".", with: "-")
+            return "claude-\(family)-\(version)"
+        }
+
+        let parts = text.components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+        var id = parts.joined(separator: "-")
+        if !id.hasPrefix("claude-") {
+            id = "claude-" + id
+        }
+        return id
     }
 }
 

--- a/ClaudeStatisticsTests/PricingFetchServiceTests.swift
+++ b/ClaudeStatisticsTests/PricingFetchServiceTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Claude_Statistics
+
+final class PricingFetchServiceTests: XCTestCase {
+    func testParsesNewModelsWithoutFallingBackToOlderVersion() throws {
+        let html = table(rows: [
+            row("Claude Opus 4.8", input: "5", cache5m: "6.25", cache1h: "10", cacheRead: "0.50", output: "25"),
+            row("Claude Mythos 5 (<a>limited availability</a>)", input: "10", cache5m: "12.50", cache1h: "20", cacheRead: "1", output: "50"),
+        ])
+
+        let pricing = try PricingFetchService.shared.parsePricingFromHTML(html)
+
+        XCTAssertEqual(pricing["claude-opus-4-8"]?.output, 25)
+        XCTAssertNil(pricing["claude-opus-4-20250514"])
+        XCTAssertEqual(pricing["claude-mythos-5"]?.input, 10)
+    }
+
+    func testKeepsFirstCurrentRateWhenDocsIncludeFutureRate() throws {
+        let html = table(rows: [
+            row("Claude Sonnet 5 through August 31, 2026", input: "2", cache5m: "2.50", cache1h: "4", cacheRead: "0.20", output: "10"),
+            row("Claude Sonnet 5 starting September 1, 2026", input: "3", cache5m: "3.75", cache1h: "6", cacheRead: "0.30", output: "15"),
+        ])
+
+        let pricing = try PricingFetchService.shared.parsePricingFromHTML(html)
+
+        XCTAssertEqual(pricing["claude-sonnet-5"]?.input, 2)
+        XCTAssertEqual(pricing["claude-sonnet-5"]?.output, 10)
+    }
+
+    func testKeepsFirstDuplicateStandardRow() throws {
+        let html = table(rows: [
+            row("Claude Opus 4.8", input: "5", cache5m: "6.25", cache1h: "10", cacheRead: "0.50", output: "25"),
+            row("Claude Opus 4.8", input: "2.50", cache5m: "3.125", cache1h: "5", cacheRead: "0.25", output: "12.50"),
+        ])
+
+        let pricing = try PricingFetchService.shared.parsePricingFromHTML(html)
+
+        XCTAssertEqual(pricing["claude-opus-4-8"]?.input, 5)
+        XCTAssertEqual(pricing["claude-opus-4-8"]?.output, 25)
+    }
+
+    private func table(rows: [String]) -> String {
+        "<table><tbody>\(rows.joined())</tbody></table>"
+    }
+
+    private func row(
+        _ model: String,
+        input: String,
+        cache5m: String,
+        cache1h: String,
+        cacheRead: String,
+        output: String
+    ) -> String {
+        """
+        <tr>
+          <td>\(model)</td><td>$\(input) / MTok</td><td>$\(cache5m) / MTok</td>
+          <td>$\(cache1h) / MTok</td><td>$\(cacheRead) / MTok</td><td>$\(output) / MTok</td>
+        </tr>
+        """
+    }
+}


### PR DESCRIPTION
## What changed

- Normalize pricing-page model names into canonical Anthropic API IDs instead of using broad substring matches.
- Preserve dated aliases for older Claude models while automatically supporting newly listed model families and versions.
- Keep the first standard-rate row when the docs also list future, promotional, or duplicate pricing rows.
- Add regression coverage for Opus 4.8, new model families, future-dated Sonnet 5 pricing, and duplicate tiers.

## Why

The pricing page now contains models and time-based rows that the old hardcoded matcher did not anticipate. For example, `Claude Opus 4.8` fell through to the broad `opus 4` match and was saved under the older Opus 4 model ID. Duplicate future pricing rows could also overwrite the current standard rate.

## Impact

"Refresh latest pricing" now stores current Claude prices under the correct model IDs and remains usable when Anthropic adds new model families or minor versions.

## Paired change

OpenAI/Codex pricing is maintained in the separate plugin repository and is fixed in https://github.com/sj719045032/claude-statistics-plugins/pull/4.

## Validation

- `PricingFetchServiceTests` passes (3 tests).
- Parsed the current full Anthropic pricing HTML successfully, including Opus 4.8, Sonnet 5, and Mythos 5.
- Debug and Release app builds succeeded on macOS.
- The full upstream suite still has three unrelated existing `TerminalIdentityResolverTests` failures; the new pricing tests pass independently.
