### PR TITLE
fix(focus): honour focus-silence for terminals without an AppleScript prober

### DIFF
--- a/ClaudeStatistics/TerminalFocus/TerminalFocusCoordinator.swift
+++ b/ClaudeStatistics/TerminalFocus/TerminalFocusCoordinator.swift
@@ -508,18 +508,65 @@ actor TerminalFocusCoordinator {
             )
         }
         // Fallback for non-AppleScript terminals (Kitty / WezTerm /
-        // Alacritty / Warp / unknown): just check if our pid is the
-        // frontmost app's pid.
-        guard let pid else { return false }
+        // Alacritty / Warp / Termius / unknown). See
+        // `frontmostMatchesSession` for why the bundle id — not the pid —
+        // is the load-bearing comparison.
+        var frontmostBundleId: String?
         var frontmostPid: pid_t?
         if Thread.isMainThread {
-            frontmostPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
+            let app = NSWorkspace.shared.frontmostApplication
+            frontmostBundleId = app?.bundleIdentifier
+            frontmostPid = app?.processIdentifier
         } else {
             DispatchQueue.main.sync {
-                frontmostPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
+                let app = NSWorkspace.shared.frontmostApplication
+                frontmostBundleId = app?.bundleIdentifier
+                frontmostPid = app?.processIdentifier
             }
         }
-        return frontmostPid == pid
+        return frontmostMatchesSession(
+            frontmostBundleId: frontmostBundleId,
+            frontmostPid: frontmostPid,
+            terminalBundleId: bundleId,
+            sessionPid: pid
+        )
+    }
+
+    /// Answers "is the terminal hosting this session the app the user is
+    /// looking at?" for terminals with no `TerminalFrontmostSessionProbing`
+    /// conformance.
+    ///
+    /// The bundle id is the load-bearing comparison. `HookRunner` reports
+    /// the CLI's own pid (`getppid()`), never the hosting GUI app's, so the
+    /// original `frontmostPid == pid` check could only match when a
+    /// session's parent process was itself an app with a Dock presence —
+    /// which the shell under a terminal emulator never is. That silently
+    /// disabled focus-silence for every terminal without an AppleScript
+    /// dictionary (Kitty / WezTerm / Alacritty / Warp / Termius): the
+    /// setting was honoured, the probe underneath it always said "not
+    /// focused". The pid comparison stays as a second chance so GUI hosts
+    /// that do report their own pid keep behaving as before.
+    ///
+    /// Bundle-id matching is tab-blind by construction: looking at a
+    /// different tab of the same terminal still counts as focused. That is
+    /// the right trade at this precision level — these terminals are
+    /// `.appOnly`, so a card's focus button could not land on the exact tab
+    /// either, and the setting asks "is the terminal in front?", not "is
+    /// this exact tab in front?". Terminals that can answer precisely
+    /// (Apple Terminal / iTerm2 / Ghostty) never reach this fallback.
+    nonisolated static func frontmostMatchesSession(
+        frontmostBundleId: String?,
+        frontmostPid: pid_t?,
+        terminalBundleId: String?,
+        sessionPid: Int32?
+    ) -> Bool {
+        if let terminalBundleId,
+           let frontmostBundleId,
+           frontmostBundleId == terminalBundleId {
+            return true
+        }
+        guard let sessionPid, let frontmostPid else { return false }
+        return frontmostPid == sessionPid
     }
 
     private nonisolated static func focusedSessionOutputMatches(

--- a/ClaudeStatisticsTests/TerminalFocusCoordinatorTests.swift
+++ b/ClaudeStatisticsTests/TerminalFocusCoordinatorTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+
+@testable import Claude_Statistics
+
+final class TerminalFocusCoordinatorTests: XCTestCase {
+    private let sessionPid: Int32 = 4242
+    private let terminalGUIPid: pid_t = 99
+
+    func test_frontmostMatchesSession_matchesTerminalBundleInFront() {
+        // The regression this guards: a terminal with no AppleScript
+        // prober (Termius / Kitty / WezTerm / Alacritty / Warp) is the
+        // frontmost app, so focus-silence must fire even though the
+        // session pid belongs to the CLI, not the GUI app.
+        XCTAssertTrue(
+            TerminalFocusCoordinator.frontmostMatchesSession(
+                frontmostBundleId: "com.termius-dmg.mac",
+                frontmostPid: terminalGUIPid,
+                terminalBundleId: "com.termius-dmg.mac",
+                sessionPid: sessionPid
+            )
+        )
+    }
+
+    func test_frontmostMatchesSession_doesNotMatchOtherAppInFront() {
+        XCTAssertFalse(
+            TerminalFocusCoordinator.frontmostMatchesSession(
+                frontmostBundleId: "com.apple.finder",
+                frontmostPid: terminalGUIPid,
+                terminalBundleId: "com.termius-dmg.mac",
+                sessionPid: sessionPid
+            )
+        )
+    }
+
+    func test_frontmostMatchesSession_stillMatchesOnPidForGUIHosts() {
+        // Chat-app hosts that report their own pid keep the pre-existing
+        // behaviour even when the bundle id is unknown.
+        XCTAssertTrue(
+            TerminalFocusCoordinator.frontmostMatchesSession(
+                frontmostBundleId: "com.anthropic.claudefordesktop",
+                frontmostPid: sessionPid,
+                terminalBundleId: nil,
+                sessionPid: sessionPid
+            )
+        )
+    }
+
+    func test_frontmostMatchesSession_unresolvedTerminalWithMismatchedPid() {
+        XCTAssertFalse(
+            TerminalFocusCoordinator.frontmostMatchesSession(
+                frontmostBundleId: "com.apple.finder",
+                frontmostPid: terminalGUIPid,
+                terminalBundleId: nil,
+                sessionPid: sessionPid
+            )
+        )
+    }
+
+    func test_frontmostMatchesSession_noFrontmostAppIsNotFocused() {
+        XCTAssertFalse(
+            TerminalFocusCoordinator.frontmostMatchesSession(
+                frontmostBundleId: nil,
+                frontmostPid: nil,
+                terminalBundleId: "com.termius-dmg.mac",
+                sessionPid: sessionPid
+            )
+        )
+    }
+
+    func test_frontmostMatchesSession_noSessionPidFallsBackToBundleOnly() {
+        XCTAssertTrue(
+            TerminalFocusCoordinator.frontmostMatchesSession(
+                frontmostBundleId: "net.kovidgoyal.kitty",
+                frontmostPid: terminalGUIPid,
+                terminalBundleId: "net.kovidgoyal.kitty",
+                sessionPid: nil
+            )
+        )
+        XCTAssertFalse(
+            TerminalFocusCoordinator.frontmostMatchesSession(
+                frontmostBundleId: "com.apple.finder",
+                frontmostPid: terminalGUIPid,
+                terminalBundleId: "net.kovidgoyal.kitty",
+                sessionPid: nil
+            )
+        )
+    }
+}


### PR DESCRIPTION
## The bug

终端在前台时静音 ("mute while the terminal is focused") is a no-op for every terminal that doesn't ship a `TerminalFrontmostSessionProbing` conformance — Kitty, WezTerm, Alacritty, Warp, and any third-party terminal plugin. The toggle is read and honoured; the probe underneath it just always answers "not focused".

`TerminalFocusCoordinator.isSessionFocused` is exact only for the three AppleScript-able terminals. Everything else fell through to:

```swift
// Fallback for non-AppleScript terminals (Kitty / WezTerm /
// Alacritty / Warp / unknown): just check if our pid is the
// frontmost app's pid.
guard let pid else { return false }
return frontmostPid == pid
```

That `pid` is what `HookRunner` puts on the wire — `HookCLI.swift:175`, `"pid": Int(getppid())` — the **CLI process**. `NSWorkspace.frontmostApplication.processIdentifier` is the **GUI app's** pid. For a shell running under a terminal emulator those can never be equal, so the fallback returns `false` unconditionally and `NotchNotificationCenter`'s focus-silence branch is unreachable.

Repro on 3.5.10, with `notch.focusSilence.enabled = 1` and the terminal frontmost:

```
INFO: Notch queued at index=0 queueCount=1 currentEvent=nil
```

Expected `Notch drop: terminal focus-silenced`.

## The fix

Compare the frontmost app's **bundle identifier** against the terminal bundle id `inferBundleId` already resolved for the session. The pid equality stays as a second chance, so GUI hosts that genuinely report their own pid (Claude.app / Codex.app) behave exactly as before — nothing that works today regresses.

The decision is extracted into a pure `frontmostMatchesSession(...)` so it's testable without `NSWorkspace`, mirroring the shape of `HookRunner.shouldDropUnclaimedHostBeforeSocket`. Six cases added in `ClaudeStatisticsTests/TerminalFocusCoordinatorTests.swift`.

**Deliberate trade:** bundle-id matching is tab-blind — a different tab of the same terminal still counts as focused. That seems right at this precision level: these terminals are `.appOnly`, so a card's focus button couldn't land on the exact tab either, and the setting asks "is the terminal in front?", not "is this exact tab in front?". Terminals that can answer precisely never reach this fallback. Happy to gate it behind `focusPrecision` if you'd rather be stricter.

## Verification

Built locally and exercised end-to-end on macOS 15 (arm64), driving the hook wrapper directly:

| Frontmost app | Before | After |
|---|---|---|
| Termius (session's terminal) | `Notch queued` | `Notch drop: terminal focus-silenced terminal=termius` |
| Finder (not the terminal) | `Notch queued` | `Notch queued` |

One caveat in the interest of full disclosure: the runtime behaviour above was verified against a local build of this fix, but I did not run `scripts/run-tests.sh` in my environment — the new unit tests are syntax-checked only, so please run them on your side.

Found while adding a Termius terminal plugin (sj719045032/claude-statistics-plugins#5); the bug is independent of that plugin and affects the shipped Kitty / WezTerm / Alacritty / Warp integrations today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
